### PR TITLE
Example how to remove copyright in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,16 @@
+<!--
+  The Footer
+-->
+
+<footer class="d-flex w-100 justify-content-center">
+  <div class="d-flex justify-content-between align-items-center text-muted">
+    <div class="footer-left">
+      <p class="mb-0">
+        © {{ 'now' | date: "%Y" }}
+        <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>.
+        {% if site.data.locales[lang].copyright.brief %}
+        <span data-toggle="tooltip" data-placement="top"
+          title="{{ site.data.locales[lang].copyright.verbose }}">{{ site.data.locales[lang].copyright.brief }}</span>
+        {% endif %}
+      </p>
+    </div>


### PR DESCRIPTION
This pull request should remove the copyright from the footer as asked in https://stackoverflow.com/questions/71706227/how-to-remove-powered-by-jekyll-with-chirpy-theme?noredirect=1#comment126739062_71706227 by creating a footer file in the _includes folder. 